### PR TITLE
Fixed missing booking after restart as internal id changed. 

### DIFF
--- a/backend/app/core/db/InitialBaseDataLoader.scala
+++ b/backend/app/core/db/InitialBaseDataLoader.scala
@@ -111,7 +111,7 @@ class InitialBaseDataLoader @Inject() (
 
   protected def initializeUser(org: Organisation, project: Project)(implicit
       dbSession: DBSession,
-      userReference: UserReference): Future[BSONObjectID] = {
+      userReference: UserReference): Future[Unit] = {
 
     val userOrg = UserOrganisation(
       org.getReference(),

--- a/backend/app/domain/UserTimeBookingAggregate.scala
+++ b/backend/app/domain/UserTimeBookingAggregate.scala
@@ -294,7 +294,8 @@ class UserTimeBookingAggregate(
           withinTransaction { implicit dbSession =>
             for {
               _ <- bookingHistoryRepository.deleteByUserReference(userReference)
-              _ <- bookingHistoryRepository.bulkInsert(s.bookings.toList)
+              _ <- bookingHistoryRepository.bulkInsert(
+                s.bookings.filter(_.end.isDefined).toList)
             } yield ()
           },
           Duration.create(5, MINUTES)

--- a/backend/app/repositories/BookingHistoryRepository.scala
+++ b/backend/app/repositories/BookingHistoryRepository.scala
@@ -143,7 +143,7 @@ class BookingHistoryMongoRepository @Inject() ()(
 
   override def upsert(t: BookingV2)(implicit
       writer: Writes[BookingId],
-      dbSession: DBSession): Future[BSONObjectID] = {
+      dbSession: DBSession): Future[Unit] = {
     logger.debug(s"insertBooking[$t]")
     super.upsert(t)
   }


### PR DESCRIPTION
* Always upsert against published ids and let mongodb handle internal _id.
* Don't store bookings without end date from snapshot