### PR TITLE
* When removing user from organisation, also drop the assignment in lastSelectedOrganisation

### DIFF
--- a/backend/app/controllers/AuthConfig.scala
+++ b/backend/app/controllers/AuthConfig.scala
@@ -55,7 +55,7 @@ trait AuthConfig {
       context: ExecutionContext,
       dbSession: DBSession): Future[Option[User]]
 
-  /** Defined handling of authorizationfailed
+  /** Defined handling of authorizationFailed
     */
   def authorizationFailed(request: RequestHeader)(implicit
       context: ExecutionContext): Future[Result]
@@ -101,5 +101,5 @@ class DefaultAuthConfig @Inject() (controllerComponents: ControllerComponents,
 
   override def authorizationFailed(request: RequestHeader)(implicit
       context: ExecutionContext): Future[Result] =
-    Future.successful(Unauthorized(Json.obj("message" -> "Unauthorized")))
+    Future.successful(Forbidden(Json.obj("message" -> "Unauthorized")))
 }

--- a/backend/test/controllers/InvitationsControllerSpec.scala
+++ b/backend/test/controllers/InvitationsControllerSpec.scala
@@ -561,7 +561,7 @@ class InvitationsControllerSpec
       contentAsString(result) must equalTo("illegal_access")
     }
 
-    "unauthorized if user is not a member of the provided organisation" in new WithTestApplication {
+    "forbidden if user is not a member of the provided organisation" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
       val authConfig: AuthConfig                      = inject[AuthConfig]
@@ -580,7 +580,7 @@ class InvitationsControllerSpec
       val result: Future[Result] =
         controller.accept(invitationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "for JoinProjectInvitation" in {

--- a/backend/test/controllers/ProjectsControllerSpec.scala
+++ b/backend/test/controllers/ProjectsControllerSpec.scala
@@ -44,7 +44,7 @@ class ProjectsControllerSpec
 
   "create project" should {
 
-    "unauthorized create project in organisation not assigned to user" in new WithTestApplication {
+    "forbidden create project in organisation not assigned to user" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -63,7 +63,7 @@ class ProjectsControllerSpec
       val result: Future[Result] =
         controller.createProject(OrganisationId())(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "badrequest blank key was specified" in new WithTestApplication {
@@ -157,7 +157,7 @@ class ProjectsControllerSpec
   }
 
   "deactivate project" should {
-    "unauthorized if user is not assigned to organisation" in new WithTestApplication {
+    "forbidden if user is not assigned to organisation" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -172,7 +172,7 @@ class ProjectsControllerSpec
         controller.deactivateProject(OrganisationId(), controller.project.id)(
           request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
     "badrequest if project id does not exist for given organisation" in new WithTestApplication {
 
@@ -229,7 +229,7 @@ class ProjectsControllerSpec
   }
 
   "invite user to project" should {
-    "unauthorized if user is not assigned to organisation" in new WithTestApplication {
+    "forbidden if user is not assigned to organisation" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -246,10 +246,10 @@ class ProjectsControllerSpec
       val result: Future[Result] =
         controller.inviteUser(OrganisationId(), controller.project.id)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
-    "unauthorized if user is OrganisationMember and not assigned to project as ProjectAdministrator" in new WithTestApplication {
+    "forbidden if user is OrganisationMember and not assigned to project as ProjectAdministrator" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -270,7 +270,7 @@ class ProjectsControllerSpec
         controller.inviteUser(controller.organisationId, controller.project.id)(
           request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "badrequest if incorrect email was provided" in new WithTestApplication {
@@ -447,7 +447,7 @@ class ProjectsControllerSpec
   }
 
   "remove other user from project" should {
-    "unauthorized if user is not assigned to organisation" in new WithTestApplication {
+    "forbidden if user is not assigned to organisation" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -463,10 +463,10 @@ class ProjectsControllerSpec
                                 controller.project.id,
                                 UserId())(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
-    "unauthorized if user is OrganisationMember and not assigned as Administrator to project" in new WithTestApplication {
+    "forbidden if user is OrganisationMember and not assigned as Administrator to project" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -485,7 +485,7 @@ class ProjectsControllerSpec
                                 controller.project.id,
                                 UserId())(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     def successfulUnassignUser(controller: ProjectsControllerMock) = {
@@ -564,7 +564,7 @@ class ProjectsControllerSpec
   }
 
   "remove own user from project" should {
-    "unauthorized if user is not assigned to organisation" in new WithTestApplication {
+    "forbidden if user is not assigned to organisation" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -579,10 +579,10 @@ class ProjectsControllerSpec
         controller.unassignMyUser(OrganisationId(), controller.project.id)(
           request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
-    "unauthorized if user is not assigned to organisation" in new WithTestApplication {
+    "forbidden if user is not assigned to organisation" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -597,7 +597,7 @@ class ProjectsControllerSpec
         controller.unassignMyUser(OrganisationId(), controller.project.id)(
           request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "successful as ProjectMember" in new WithTestApplication {
@@ -653,7 +653,7 @@ class ProjectsControllerSpec
   }
 
   "update project" should {
-    "unauthorized if user is not assigned to organisation" in new WithTestApplication {
+    "forbidden if user is not assigned to organisation" in new WithTestApplication {
 
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -669,7 +669,7 @@ class ProjectsControllerSpec
         controller.updateProject(OrganisationId(), controller.project.id)(
           request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "badrequest no update was provided" in new WithTestApplication {

--- a/backend/test/controllers/SecuritySpec.scala
+++ b/backend/test/controllers/SecuritySpec.scala
@@ -21,13 +21,7 @@
 
 package controllers
 
-import core.{
-  DBSession,
-  DBSupport,
-  MockCacheAware,
-  TestApplication,
-  TestDBSupport
-}
+import core.{DBSession, MockCacheAware, TestApplication, TestDBSupport}
 import models._
 import mongo.EmbedMongo
 import org.apache.http.HttpStatus
@@ -37,6 +31,7 @@ import play.api.mvc._
 import play.api.test._
 import play.modules.reactivemongo.ReactiveMongoApi
 
+import java.util.UUID
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -99,7 +94,7 @@ class SecuritySpec
     "Fail if token is missing in cache" in new WithTestApplication {
       // prepare
       val controller = new SecurityMock(reactiveMongoApi)
-      val token      = "ghvhvh"
+      val token      = UUID.randomUUID().toString
       val request = FakeRequest()
         .withCookies(Cookie(controller.AuthTokenCookieKey, token))
         .withHeaders((controller.AuthTokenHeader, token))
@@ -178,7 +173,7 @@ class SecuritySpec
         .returns(Future.successful(None))
 
       // execute
-      val result = runHasRole(controller)
+      runHasRole(controller)
 
       // check results
       there.was(
@@ -186,7 +181,7 @@ class SecuritySpec
           .authorizationFailed(any[RequestHeader])(any[ExecutionContext]))
     }
 
-    "return unauthorized when autorization failed" in new WithTestApplication {
+    "return unauthorized when authorization failed" in new WithTestApplication {
       // prepare
       val controller = new HasRoleSecurityMock(reactiveMongoApi)
       controller.authConfig
@@ -198,7 +193,7 @@ class SecuritySpec
         .returns(Future.successful(Some(UserMock.mock(FreeUser))))
 
       // execute
-      val result = runHasRole(controller)
+      runHasRole(controller)
 
       // check results
       there.was(

--- a/backend/test/controllers/TimeBookingControllerSpec.scala
+++ b/backend/test/controllers/TimeBookingControllerSpec.scala
@@ -50,7 +50,7 @@ class TimeBookingControllerSpec
 
   "start booking" should {
 
-    "unauthorized if for authenticated user project id does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user project id does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices                              = inject[SystemServices]
       val authConfig                                  = inject[AuthConfig]
@@ -70,10 +70,10 @@ class TimeBookingControllerSpec
       val result: Future[Result] =
         controller.start(controller.organisationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
-    "badrequest if for authenticated user organisation does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user organisation does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices                              = inject[SystemServices]
       val authConfig                                  = inject[AuthConfig]
@@ -92,13 +92,13 @@ class TimeBookingControllerSpec
       val organisationId: OrganisationId = OrganisationId()
       val result: Future[Result] = controller.start(organisationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
   }
 
   "edit booking" should {
 
-    "unauthorized if for authenticated user project id does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user project id does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices                              = inject[SystemServices]
       val authConfig                                  = inject[AuthConfig]
@@ -119,10 +119,10 @@ class TimeBookingControllerSpec
       val result: Future[Result] =
         controller.edit(controller.organisationId, BookingId())(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
-    "unauthorized if for authenticated user organisation does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user organisation does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices                              = inject[SystemServices]
       val authConfig                                  = inject[AuthConfig]
@@ -143,7 +143,7 @@ class TimeBookingControllerSpec
       val result: Future[Result] =
         controller.edit(organisationId, BookingId())(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "badrequest if end date is before start date" in new WithTestApplication {
@@ -176,7 +176,7 @@ class TimeBookingControllerSpec
 
   "add booking" should {
 
-    "Unauthorized if for authenticated user project id does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user project id does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices                              = inject[SystemServices]
       val authConfig                                  = inject[AuthConfig]
@@ -197,10 +197,10 @@ class TimeBookingControllerSpec
       val result: Future[Result] =
         controller.add(controller.organisationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
-    "Unauthorized if for authenticated user organisation does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user organisation does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices                              = inject[SystemServices]
       val authConfig                                  = inject[AuthConfig]
@@ -220,7 +220,7 @@ class TimeBookingControllerSpec
       val organisationId: OrganisationId = OrganisationId()
       val result: Future[Result] = controller.add(organisationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "badrequest if end date is before start date" in new WithTestApplication {

--- a/backend/test/controllers/UserFavoritesControllerSpec.scala
+++ b/backend/test/controllers/UserFavoritesControllerSpec.scala
@@ -46,7 +46,7 @@ class UserFavoritesControllerSpec
     with EmbedMongo {
 
   "add favorite" should {
-    "Unauthorized if for authenticated user project id does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user project id does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
       val authConfig: AuthConfig                      = inject[AuthConfig]
@@ -70,10 +70,10 @@ class UserFavoritesControllerSpec
       val result: Future[Result] =
         controller.addFavorite(controller.organisationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
-    "Unauthorized if for authenticated user team does not exist" in new WithTestApplication {
+    "forbidden if for authenticated user team does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
       val authConfig: AuthConfig                      = inject[AuthConfig]
@@ -97,12 +97,12 @@ class UserFavoritesControllerSpec
       val result: Future[Result] =
         controller.addFavorite(organisationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
   }
 
   "remove favorite" should {
-    "Unauthorized if for authenticated user project id does not exist" in new WithTestApplication
+    "forbidden if for authenticated user project id does not exist" in new WithTestApplication
       with Injecting {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
@@ -127,11 +127,11 @@ class UserFavoritesControllerSpec
       val result: Future[Result] =
         controller.removeFavorite(controller.organisationId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
   }
 
-  "Unauthorized if for authenticated user team does not exist" in new WithTestApplication
+  "forbidden if for authenticated user team does not exist" in new WithTestApplication
     with Injecting {
     implicit val executionContext: ExecutionContext = inject[ExecutionContext]
     val systemServices: SystemServices              = inject[SystemServices]
@@ -156,7 +156,7 @@ class UserFavoritesControllerSpec
     val result: Future[Result] =
       controller.removeFavorite(organisationId)(request)
 
-    status(result) must equalTo(UNAUTHORIZED)
+    status(result) must equalTo(FORBIDDEN)
   }
 
 }

--- a/backend/test/controllers/UsersControllerSpec.scala
+++ b/backend/test/controllers/UsersControllerSpec.scala
@@ -172,7 +172,7 @@ class UsersControllerSpec
   }
 
   "update other user data" should {
-    "unauthorized user does not exist" in new WithTestApplication {
+    "forbidden user does not exist" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
       val authConfig: AuthConfig                      = inject[AuthConfig]
@@ -192,7 +192,7 @@ class UsersControllerSpec
       val result: Future[Result] =
         controller.updateUserData(teamId, userId)(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
   }
 
@@ -271,7 +271,7 @@ class UsersControllerSpec
   }
 
   "updateUserOrganisation" should {
-    "unauthorized if user is not assigned to organisation" in new WithTestApplication {
+    "forbidden if user is not assigned to organisation" in new WithTestApplication {
       implicit val executionContext: ExecutionContext = inject[ExecutionContext]
       val systemServices: SystemServices              = inject[SystemServices]
       val authConfig: AuthConfig                      = inject[AuthConfig]
@@ -287,7 +287,7 @@ class UsersControllerSpec
       val result: Future[Result] =
         controller.updateMyUserOrganisationData(OrganisationId())(request)
 
-      status(result) must equalTo(UNAUTHORIZED)
+      status(result) must equalTo(FORBIDDEN)
     }
 
     "ok" in new WithTestApplication {


### PR DESCRIPTION
* When removing user from organisation, also drop the assignment in lastSelectedOrganisation.

* Return FORBIDDEN instead of UNAUTHORIZED in case user tries to access a resource he's not allowed so frontend can react to it other than performing a logout