### PR TITLE
 Fix refresh token handling

### DIFF
--- a/backend/app/controllers/SimpleInternalDataHandler.scala
+++ b/backend/app/controllers/SimpleInternalDataHandler.scala
@@ -76,12 +76,10 @@ class SimpleInternalDataHandler(
     }
 
   def getStoredAccessToken(
-      authInfo: AuthInfo[OAuthUser]): Future[Option[AccessToken]] =
-    withDBSession() { implicit dbSession =>
-      oauthAccessTokenRepository
-        .findByAuthInfo(authInfo)
-        .map(_.map(_.toAccessToken))
-    }
+      authInfo: AuthInfo[OAuthUser]): Future[Option[AccessToken]] = {
+    // always create new token to allow multiple concurrent sessions of the same user
+    Future.successful(None)
+  }
 
   def refreshAccessToken(authInfo: AuthInfo[OAuthUser],
                          refreshToken: String): Future[AccessToken] =

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -23,7 +23,9 @@ import { NextResponse } from 'next/server';
 
 export default withAuth(
   async (request: NextRequestWithAuth) => {
-    console.debug('[Middleware][Request]', request.url, request.nextauth.token);
+    if (process.env.LASIUS_DEBUG) {
+      console.debug('[Middleware][Request]', request.url, request.nextauth.token);
+    }
 
     //
     // This middleware implements a workaround as next-auth has some issues storing the
@@ -39,7 +41,9 @@ export default withAuth(
       request.nextauth.token?.expires_at &&
       Date.now() >= request.nextauth.token.expires_at * 1000
     ) {
-      console.debug('[Middleware][AccessTokenExpired]');
+      if (process.env.LASIUS_DEBUG) {
+        console.debug('[Middleware][AccessTokenExpired]');
+      }
       const session = await fetch(`${process.env.NEXTAUTH_URL}/api/auth/session`, {
         headers: {
           'content-type': 'application/json',
@@ -49,7 +53,9 @@ export default withAuth(
       const json = await session.json();
       const data = Object.keys(json).length > 0 ? json : null;
 
-      console.debug('[Middleware][AccessTokenChanged]', data);
+      if (process.env.LASIUS_DEBUG) {
+        console.debug('[Middleware][AccessTokenChanged]', data);
+      }
       setCookies = session.headers.getSetCookie();
 
       // use cookie already for queued request
@@ -60,7 +66,9 @@ export default withAuth(
           request.cookies.set(cookieName, setCookieValues[0]);
         });
         requestHeaders.set('Cookie', request.cookies.toString());
-        console.debug('[Middleware][Request][UpgradedCookies]', request.cookies);
+        if (process.env.LASIUS_DEBUG) {
+          console.debug('[Middleware][UpgradedCookies]', request.cookies);
+        }
       }
     }
 
@@ -73,7 +81,9 @@ export default withAuth(
       setCookies.forEach((cookie) => {
         res.headers.append('Set-Cookie', cookie);
       });
-      console.debug('[Middleware][Response][SetCookies]', setCookies);
+      if (process.env.LASIUS_DEBUG) {
+        console.debug('[Middleware][Response][SetCookies]', setCookies);
+      }
     }
 
     return res;
@@ -89,7 +99,6 @@ export default withAuth(
 export const config = {
   //  Require authentication for the following routes
   matcher: [
-    '/api/auth/session',
     '/user',
     '/user/(.*)',
     '/organisation',

--- a/frontend/src/pages/organisation/lists.tsx
+++ b/frontend/src/pages/organisation/lists.tsx
@@ -23,14 +23,12 @@ import { LayoutDesktop } from 'layout/layoutDesktop';
 import { NextPageWithLayout } from 'pages/_app';
 import { Error } from 'components/error';
 import { BookingHistoryLayout } from 'components/bookingHistory/bookingHistoryLayout';
-import { getUserProfile } from 'lib/api/lasius/user/user';
 import { isAdminOfCurrentOrg } from 'lib/api/functions/isAdminOfCurrentOrg';
 import { ModelsUser } from 'lib/api/lasius';
-import { getRequestHeaders } from 'lib/api/hooks/useTokensWithAxiosRequests';
-import { nextAuthOptions } from 'pages/api/auth/[...nextauth]';
-import { getServerSession } from 'next-auth';
+import { useProfile } from 'lib/api/hooks/useProfile';
 
-const ListsPage: NextPageWithLayout = ({ profile }) => {
+const ListsPage: NextPageWithLayout = () => {
+  const { profile } = useProfile();
   if (isAdminOfCurrentOrg(profile as ModelsUser)) {
     return <BookingHistoryLayout dataSource="organisationBookings" />;
   }
@@ -39,13 +37,8 @@ const ListsPage: NextPageWithLayout = ({ profile }) => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { locale = '' } = context;
-  const session = await getServerSession(context.req, context.res, nextAuthOptions);
-  const profile = session?.access_token
-    ? await getUserProfile(getRequestHeaders(session.access_token, session.access_token_issuer))
-    : undefined;
   return {
     props: {
-      profile,
       ...(await serverSideTranslations(locale, ['common'])),
     },
   };

--- a/frontend/src/pages/organisation/projects.tsx
+++ b/frontend/src/pages/organisation/projects.tsx
@@ -25,12 +25,10 @@ import { NextPageWithLayout } from 'pages/_app';
 import { Error } from 'components/error';
 import { isAdminOfCurrentOrg } from 'lib/api/functions/isAdminOfCurrentOrg';
 import { ModelsUser } from 'lib/api/lasius';
-import { getUserProfile } from 'lib/api/lasius/user/user';
-import { getRequestHeaders } from 'lib/api/hooks/useTokensWithAxiosRequests';
-import { getServerSession } from 'next-auth';
-import { nextAuthOptions } from 'pages/api/auth/[...nextauth]';
+import { useProfile } from 'lib/api/hooks/useProfile';
 
-const AllProjectsPage: NextPageWithLayout = ({ profile }) => {
+const AllProjectsPage: NextPageWithLayout = () => {
+  const { profile } = useProfile();
   if (isAdminOfCurrentOrg(profile as ModelsUser)) {
     return <AllProjectsLayout />;
   }
@@ -39,13 +37,8 @@ const AllProjectsPage: NextPageWithLayout = ({ profile }) => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { locale = '' } = context;
-  const session = await getServerSession(context.req, context.res, nextAuthOptions);
-  const profile = session?.access_token
-    ? await getUserProfile(getRequestHeaders(session.access_token, session.access_token_issuer))
-    : undefined;
   return {
     props: {
-      profile,
       ...(await serverSideTranslations(locale, ['common'])),
     },
   };

--- a/frontend/src/pages/organisation/stats.tsx
+++ b/frontend/src/pages/organisation/stats.tsx
@@ -23,14 +23,12 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { LayoutDesktop } from 'layout/layoutDesktop';
 import { NextPageWithLayout } from 'pages/_app';
 import { Error } from 'components/error';
-import { getUserProfile } from 'lib/api/lasius/user/user';
 import { isAdminOfCurrentOrg } from 'lib/api/functions/isAdminOfCurrentOrg';
 import { ModelsUser } from 'lib/api/lasius';
-import { getRequestHeaders } from 'lib/api/hooks/useTokensWithAxiosRequests';
-import { getServerSession } from 'next-auth';
-import { nextAuthOptions } from 'pages/api/auth/[...nextauth]';
+import { useProfile } from 'lib/api/hooks/useProfile';
 
-const StatsPage: NextPageWithLayout = ({ profile }) => {
+const StatsPage: NextPageWithLayout = () => {
+  const { profile } = useProfile();
   if (isAdminOfCurrentOrg(profile as ModelsUser)) {
     return <StatsLayout />;
   }
@@ -39,13 +37,8 @@ const StatsPage: NextPageWithLayout = ({ profile }) => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { locale = '' } = context;
-  const session = await getServerSession(context.req, context.res, nextAuthOptions);
-  const profile = session?.access_token
-    ? await getUserProfile(getRequestHeaders(session.access_token, session.access_token_issuer))
-    : undefined;
   return {
     props: {
-      profile,
       ...(await serverSideTranslations(locale, ['common'])),
     },
   };

--- a/frontend/src/pages/user/home.tsx
+++ b/frontend/src/pages/user/home.tsx
@@ -24,8 +24,6 @@ import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { LayoutMobile } from 'layout/layoutMobile';
 import { LayoutDesktop } from 'layout/layoutDesktop';
-import { getServerSession } from 'next-auth';
-import { nextAuthOptions } from 'pages/api/auth/[...nextauth]';
 
 type DeviceType = {
   deviceType: 'desktop' | 'mobile';
@@ -39,8 +37,6 @@ const Home: NextPageWithLayout<DeviceType> = (context) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getServerSession(context.req, context.res, nextAuthOptions);
-  console.info('[Home][Session]', session);
   const { locale = '' } = context;
   const UA = context.req.headers['user-agent'];
   const isMobile = Boolean(


### PR DESCRIPTION
Fix refresh token handling by:
    * prevent duplicate requests to update same refresh token twice
    * share client side profile to prevent multiple server side session requests
    * allow user to login multiple time in different browsers and fetch multiple access tokens from internal oauth provider
