### PR TITLE
Fix url to request new access_token based on refresh token

### DIFF
--- a/docs/Auth.md
+++ b/docs/Auth.md
@@ -1,6 +1,5 @@
 [DE](DE%3AAuth.md)
 
-
 # Authentication (Login)
 
 Lasius supports [OAuth2](https://auth0.com/de/intro-to-iam/what-is-oauth-2) and [OpenId Connect](https://openid.net/developers/how-connect-works/-based user authentication. That allows Lasius to be operated with existing identity providers (IDPs) and support single sign-on or machine-to-machine communication.
@@ -34,15 +33,16 @@ However, to simplify installations for demonstration purposes and development en
 The internal OAuth2 provider can be activated and configured either using environment variables or a separate backend configuration. For the frontend, only `LASIUS_OAUTH_CLIENT_ID` and `LASIUS_OAUTH_CLIENT_SECRET` need to be defined, so that the provider appears in the list of authentication providers.
 
 #### Configuration
-| Environment variable | Description |
-|---|--|
-| LASIUS_OAUTH_PROVIDER_ENABLED              | Enable or disable the internal OAuth2 provider |
-| LASIUS_OAUTH_PROVIDER_ALLOW_REGISTER_USERS | Allow registration of new users on the internal OAuth provider |
-| LASIUS_OAUTH_CLIENT_ID | Client ID of the frontend application. It is recommended to use a unique ID per application case |
-| LASIUS_OAUTH_CLIENT_SECRET | Client secret of the frontend application. It is recommended to use a unique secret per application case |
-| LASIUS_INTERNAL_JWT_PRIVATE_KEY | Private key used for signing the internal JWT token. It is recommended to use a unique key per application case |
 
-Additional parameters such as the lifespan of the JWT token must be defined using a separate backend configuration. The corresponding default values in the `lasius.security.oauth-2-provider` section of the [application.conf](https://github.com/tegonal/Lasius/blob/main/backend/conf/application.conf)  configuration can be overridden accordingly.
+| Environment variable                       | Description                                                                                                     |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| LASIUS_OAUTH_PROVIDER_ENABLED              | Enable or disable the internal OAuth2 provider                                                                  |
+| LASIUS_OAUTH_PROVIDER_ALLOW_REGISTER_USERS | Allow registration of new users on the internal OAuth provider                                                  |
+| LASIUS_OAUTH_CLIENT_ID                     | Client ID of the frontend application. It is recommended to use a unique ID per application case                |
+| LASIUS_OAUTH_CLIENT_SECRET                 | Client secret of the frontend application. It is recommended to use a unique secret per application case        |
+| LASIUS_INTERNAL_JWT_PRIVATE_KEY            | Private key used for signing the internal JWT token. It is recommended to use a unique key per application case |
+
+Additional parameters such as the lifespan of the JWT token must be defined using a separate backend configuration. The corresponding default values in the `lasius.security.oauth-2-provider` section of the [application.conf](https://github.com/tegonal/Lasius/blob/main/backend/conf/application.conf) configuration can be overridden accordingly.
 
 ### Gitlab
 
@@ -50,21 +50,21 @@ To enable authentication via a public [Gitlab](https://gitlab.com) instance or a
 
 https://gitlab.com/-/profile/applications
 
-The callback-Url need to be created based on the following pattern: `https://<hostname>/api/auth/callback/gitlab`, where `<hostname>` needs to be replaced with the public name of the lasius instance. Die application needs to have the scopes `openid`, `profile` and `email`.
+The callback-Url need to be created based on the following pattern: `https://<hostname>/api/auth/callback/gitlab`, where `<hostname>` needs to be replaced with the public name of the lasius instance. Die application needs to have the scopes `openid` and `email`.
 
 Once the provider is entered in the backend configuration, Gitlab integration can be configured using the following environment variables:
 
-| Environment variable | Description |
-|---|--|
-| GITLAB_OAUTH_URL (optional) | URL of the Gitlab instance to be used as an authentication provider |
-| GITLAB_OAUTH_CLIENT_ID | Client ID of the application registered with Gitlab |
-| GITLAB_OAUTH_CLIENT_SECRET | Client secret of the application registered with Gitlab |
-| GITLAB_OAUTH_INTROSPECTION_PATH (optional) | Path for the introspection endpoint to verify the access token |
-| GITLAB_OAUTH_USER_INFO_PATH (optional) | Path for loading the user profile |
+| Environment variable                       | Description                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------- |
+| GITLAB_OAUTH_URL (optional)                | URL of the Gitlab instance to be used as an authentication provider |
+| GITLAB_OAUTH_CLIENT_ID                     | Client ID of the application registered with Gitlab                 |
+| GITLAB_OAUTH_CLIENT_SECRET                 | Client secret of the application registered with Gitlab             |
+| GITLAB_OAUTH_INTROSPECTION_PATH (optional) | Path for the introspection endpoint to verify the access token      |
+| GITLAB_OAUTH_USER_INFO_PATH (optional)     | Path for loading the user profile                                   |
 
 ### Github
 
-To integrate  [Github](https://github.com) as an authentication provider, the Oauth application must be registered with Github:
+To integrate [Github](https://github.com) as an authentication provider, the Oauth application must be registered with Github:
 
 https://github.com/settings/developers
 
@@ -72,9 +72,9 @@ The callback-Url need to be created based on the following pattern: `https://<ho
 
 Once the provider is entered in the backend configuration, Github integration can be configured using the following environment variables:
 
-| Environment variable | Description |
-|---|--|
-| GITHUB_OAUTH_CLIENT_ID | Client ID of the application registered with Github |
+| Environment variable       | Description                                             |
+| -------------------------- | ------------------------------------------------------- |
+| GITHUB_OAUTH_CLIENT_ID     | Client ID of the application registered with Github     |
 | GITHUB_OAUTH_CLIENT_SECRET | Client secret of the application registered with Github |
 
 ### Keycloak
@@ -85,10 +85,10 @@ The callback-Url need to be created based on the following pattern: `https://<ho
 
 Once the client is entered in the Keycloak configuration, Keycloak integration can be configured using the following environment variables:
 
-| Environment variable | Description |
-|---|--|
-| KEYCLOAK_OAUTH_URL | URL of the Keycloak instance |
-| KEYCLOAK_OAUTH_CLIENT_ID | Client ID of the registered application |
+| Environment variable         | Description                                 |
+| ---------------------------- | ------------------------------------------- |
+| KEYCLOAK_OAUTH_URL           | URL of the Keycloak instance                |
+| KEYCLOAK_OAUTH_CLIENT_ID     | Client ID of the registered application     |
 | KEYCLOAK_OAUTH_CLIENT_SECRET | Client secret of the registered application |
 
 Additionally, the integration in the frontend can be customized using the following environment variables:
@@ -96,4 +96,3 @@ Additionally, the integration in the frontend can be customized using the follow
 |---|--|
 | KEYCLOAK_OAUTH_PROVIDER_NAME | Name in the list of authentication providers |
 | KEYCLOAK_OAUTH_PROVIDER_ICON | Path to a specific icon. This must be included in the frontend, either through a custom build or by including a local file when starting a Docker image |
-

--- a/docs/DE:Auth.md
+++ b/docs/DE:Auth.md
@@ -10,7 +10,7 @@ Lasius unterstützt konfiguratorisch unterschiedliche Authentication Providers. 
 
 ### Konfiguration
 
-Die zur Verfügung stehenden Authentication Providers müssen sowohl im Frontend, als auch im Backend aktiviert werden, insofern eine Anmeldung über das Lasius Frontend zur Verfügung stehen soll. 
+Die zur Verfügung stehenden Authentication Providers müssen sowohl im Frontend, als auch im Backend aktiviert werden, insofern eine Anmeldung über das Lasius Frontend zur Verfügung stehen soll.
 
 #### Backend Konfiguration
 
@@ -34,13 +34,13 @@ Der interne OAuth2 Provider kann entweder mittels Umgebungsvariablen oder mit ei
 
 #### Konfiguration
 
-| Umgebungsvariable | Beschreibung |
-|---|--|
-| LASIUS_OAUTH_PROVIDER_ENABLED              | Aktivieren oder deaktivieren des internen OAuth2 Providers |
-| LASIUS_OAUTH_PROVIDER_ALLOW_REGISTER_USERS | Ermöglicht das Registrieren von neuen Benutzern auf dem internen OAuth Provider |
-| LASIUS_OAUTH_CLIENT_ID | Client ID der Frontend Applikation. Es wird empfohlen, je Anwendungsfall eine eigene id zu verwenden |
-| LASIUS_OAUTH_CLIENT_SECRET | Client Secret der Frontend Applikation. Es wird empfohlen, je Anwendungsfall eine eigenes Secret zu verwenden |
-| LASIUS_INTERNAL_JWT_PRIVATE_KEY | Schlüssel, welcher für das Signieren des internen JWT Tokens verwendet wird. Es wird empfolgen, je Anwendungsfall einen eigenen Schlüssel zu verwenden |
+| Umgebungsvariable                          | Beschreibung                                                                                                                                           |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| LASIUS_OAUTH_PROVIDER_ENABLED              | Aktivieren oder deaktivieren des internen OAuth2 Providers                                                                                             |
+| LASIUS_OAUTH_PROVIDER_ALLOW_REGISTER_USERS | Ermöglicht das Registrieren von neuen Benutzern auf dem internen OAuth Provider                                                                        |
+| LASIUS_OAUTH_CLIENT_ID                     | Client ID der Frontend Applikation. Es wird empfohlen, je Anwendungsfall eine eigene id zu verwenden                                                   |
+| LASIUS_OAUTH_CLIENT_SECRET                 | Client Secret der Frontend Applikation. Es wird empfohlen, je Anwendungsfall eine eigenes Secret zu verwenden                                          |
+| LASIUS_INTERNAL_JWT_PRIVATE_KEY            | Schlüssel, welcher für das Signieren des internen JWT Tokens verwendet wird. Es wird empfolgen, je Anwendungsfall einen eigenen Schlüssel zu verwenden |
 
 Weitere Parameter wie Lifespan des JWT Tokens müssen mittels separater Backend-Konfiguration definiert werden. Die entsprechenden Standardwerte in der Sektion `lasius.security.oauth-2-provider` aus der [application.conf](https://github.com/tegonal/Lasius/blob/main/backend/conf/application.conf) Konfiguration können dabei entsprechend überschrieben werden.
 
@@ -50,17 +50,17 @@ Damit eine Authentisierung via öffentlicher [Gitlab](https://gitlab.com) Instan
 
 https://gitlab.com/-/profile/applications
 
-Die Callback-Url muss wie folgt erfasst werden: `https://<hostname>/api/auth/callback/gitlab`, wobei `<hostname>` mit dem öffentlich erreichbaren Namen der Instanz ersetzt werden muss. Die Applikation benötigt die Scopes `openid`, `profile` und `email`.
+Die Callback-Url muss wie folgt erfasst werden: `https://<hostname>/api/auth/callback/gitlab`, wobei `<hostname>` mit dem öffentlich erreichbaren Namen der Instanz ersetzt werden muss. Die Applikation benötigt die Scopes `openid` und `email`.
 
 Danach kann die Gitlab-Integration über folgende Umgebungsvariablen konfiguriert werden, insofern der Anbieter in der Backend-Konfiguration erfasst wurde:
 
-| Umgebungsvariable | Beschreibung |
-|---|--|
-| GITLAB_OAUTH_URL (optional) | Url der Gitlab Instanz, welche als Authentication Provider verwendet werden soll |
-| GITLAB_OAUTH_CLIENT_ID | Client Id der bei Gitlab registrierten Applikation |
-| GITLAB_OAUTH_CLIENT_SECRET | Client secret der bei Gitlab registrierten Applikation |
-| GITLAB_OAUTH_INTROSPECTION_PATH (optional) | Pfad für den Introspection Endpoint zur Prüfung des Access Tokens |
-| GITLAB_OAUTH_USER_INFO_PATH (optional) | Pfad für das Laden des Benutzerprofils |
+| Umgebungsvariable                          | Beschreibung                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------------- |
+| GITLAB_OAUTH_URL (optional)                | Url der Gitlab Instanz, welche als Authentication Provider verwendet werden soll |
+| GITLAB_OAUTH_CLIENT_ID                     | Client Id der bei Gitlab registrierten Applikation                               |
+| GITLAB_OAUTH_CLIENT_SECRET                 | Client secret der bei Gitlab registrierten Applikation                           |
+| GITLAB_OAUTH_INTROSPECTION_PATH (optional) | Pfad für den Introspection Endpoint zur Prüfung des Access Tokens                |
+| GITLAB_OAUTH_USER_INFO_PATH (optional)     | Pfad für das Laden des Benutzerprofils                                           |
 
 ### Github
 
@@ -72,26 +72,23 @@ Die Callback-Url muss wie folgt erfasst werden: `https://<hostname>/api/auth/cal
 
 Danach kann die Github-Integration über folgende Umgebungsvariablen konfiguriert werden, insofern der Anbieter in der Backend-Konfiguration erfasst wurde:
 
-| Umgebungsvariable | Beschreibung |
-|---|--|
-| GITHUB_OAUTH_CLIENT_ID | Client Id der bei Github registrierten Applikation |
+| Umgebungsvariable          | Beschreibung                                           |
+| -------------------------- | ------------------------------------------------------ |
+| GITHUB_OAUTH_CLIENT_ID     | Client Id der bei Github registrierten Applikation     |
 | GITHUB_OAUTH_CLIENT_SECRET | Client secret der bei Github registrierten Applikation |
-
 
 ### Keycloak
 
-Lasius unterstützt die Integration einer [Keycloak](https://keycloak.org) Instanz als Authentication Provider. Dazu muss in der Keycloak Instanz ein entsprechender [OpenID Connect Client](https://www.keycloak.org/docs/latest/server_admin/index.html#_oidc_clients) registriert werden. 
-
+Lasius unterstützt die Integration einer [Keycloak](https://keycloak.org) Instanz als Authentication Provider. Dazu muss in der Keycloak Instanz ein entsprechender [OpenID Connect Client](https://www.keycloak.org/docs/latest/server_admin/index.html#_oidc_clients) registriert werden.
 
 Die Callback-Url muss wie folgt erfasst werden: `https://<hostname>/api/auth/callback/custom_keycloak`, wobei `<hostname>` mit dem öffentlich erreichbaren Namen der Instanz ersetzt werden muss.
 
-
 Danach kann die Keycloak Instanz über folgende Umgebungsvariablen konfiguriert werden, insofern der Anbieter in der Backend-Konfiguration erfasst wurde:
 
-| Umgebungsvariable | Beschreibung |
-|---|--|
-| KEYCLOAK_OAUTH_URL | Url der Keycloak Instanz |
-| KEYCLOAK_OAUTH_CLIENT_ID | Client Id der registrierten Applikation |
+| Umgebungsvariable            | Beschreibung                                |
+| ---------------------------- | ------------------------------------------- |
+| KEYCLOAK_OAUTH_URL           | Url der Keycloak Instanz                    |
+| KEYCLOAK_OAUTH_CLIENT_ID     | Client Id der registrierten Applikation     |
 | KEYCLOAK_OAUTH_CLIENT_SECRET | Client secret der registrierten Applikation |
 
 Zusätzlich kann die Integration im Frontend über folgende Umgebungsvariabeln individualisiert werden:
@@ -99,4 +96,3 @@ Zusätzlich kann die Integration im Frontend über folgende Umgebungsvariabeln i
 |---|--|
 | KEYCLOAK_OAUTH_PROVIDER_NAME | Name in der Liste der Authentication Providers |
 | KEYCLOAK_OAUTH_PROVIDER_ICON | Pfad auf ein spezifisches Icon. Dieses muss im Frontend eingebunden werden, entweder durch einen eigenen Build oder durch das Einbinden einer lokalen Datei beim Starten eines Docker Images |
-

--- a/frontend/src/pages/api/auth/[...nextauth].ts
+++ b/frontend/src/pages/api/auth/[...nextauth].ts
@@ -73,7 +73,7 @@ const internalProvider: OAuthConfig<any> = {
 async function requestRefreshToken(refresh_token: string, provider?: string): Promise<any> {
   switch (provider) {
     case 'gitlab':
-      return await fetch(gitlabUrl + '/oauth/access_token', {
+      return await fetch(gitlabUrl + '/oauth/token', {
         method: 'POST',
         body: new URLSearchParams({
           grant_type: 'refresh_token',
@@ -83,7 +83,7 @@ async function requestRefreshToken(refresh_token: string, provider?: string): Pr
         }),
       });
     case 'github':
-      return await fetch(githubUrl + '/oauth/access_token', {
+      return await fetch('https://github.com/login/oauth/access_token', {
         method: 'POST',
         body: new URLSearchParams({
           grant_type: 'refresh_token',
@@ -196,7 +196,7 @@ if (process.env.GITLAB_OAUTH_CLIENT_ID && process.env.GITLAB_OAUTH_CLIENT_SECRET
       clientId: process.env.GITLAB_OAUTH_CLIENT_ID,
       clientSecret: process.env.GITLAB_OAUTH_CLIENT_SECRET,
       wellKnown: gitlabUrl + '/.well-known/openid-configuration',
-      authorization: { params: { scope: 'openid email profile' } },
+      authorization: { params: { scope: 'openid email' } },
       profile(profile) {
         return {
           id: (profile.id || profile.sub).toString(),
@@ -214,6 +214,10 @@ if (process.env.GITHUB_OAUTH_CLIENT_ID && process.env.GITHUB_OAUTH_CLIENT_SECRET
     GitHub({
       clientId: process.env.GITHUB_OAUTH_CLIENT_ID,
       clientSecret: process.env.GITHUB_OAUTH_CLIENT_SECRET,
+      authorization: {
+        url: 'https://github.com/login/oauth/authorize',
+        params: { scope: 'user:email' },
+      },
       profile(profile) {
         return {
           id: profile.id.toString(),


### PR DESCRIPTION
Additionally:
* limit oauth scopes of gitlab and github to the minimal once used in lasius