### PR TITLE
Dev/fixes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,7 +102,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.46.1",
     "concurrently": "^9.2.1",
-    "daisyui": "^5.3.0",
+    "daisyui": "^5.3.2",
     "dotenv-cli": "^10.0.0",
     "eslint": "9.37.0",
     "eslint-config-airbnb": "^19.0.4",
@@ -120,7 +120,7 @@
     "jsonc-eslint-parser": "^2.4.1",
     "orval": "7.13.2",
     "prettier": "^3.6.2",
-    "prettier-plugin-tailwindcss": "^0.6.14",
+    "prettier-plugin-tailwindcss": "^0.7.0",
     "svgo": "^4.0.0",
     "tailwindcss": "4.1.14",
     "typescript": "5.9.3"

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -94,6 +94,9 @@
     "getStartedFree": "Starte mit Open-Source Zeiterfassung",
     "joinLasius": "Bei Lasius mitmachen",
     "needHelp": "Brauchst du Hilfe? Klicke auf die Hilfe-Schaltfläche",
+    "needsAccount": {
+      "message": "Um die Einladung anzunehmen, melde dich bitte mit {{email}} an oder erstelle ein neues Konto mit einem der unten aufgeführten Anbieter."
+    },
     "noAuthMethodsAvailable": "Keine Authentifizierungsmethoden verfügbar",
     "preparingSecureLogin": "Sichere Anmeldung wird vorbereitet...",
     "providers": {
@@ -392,8 +395,16 @@
     "inviteProjectDescription": "Gib die E-Mail-Adresse der Person ein, die du einladen möchtest. Ein Einladungslink wird generiert, den du ihr senden kannst.",
     "messages": {
       "invitedToOrganisation": "Du wurdest von {{inviter}} eingeladen, der Organisation {{organisation}} beizutreten.",
+      "invitedToOrganisationNeedsAccount": "You have been invited by {{inviter}} to join organisation {{organisation}}.",
       "invitedToProject": "Du wurdest von {{inviter}} eingeladen, dem Projekt {{project}} beizutreten.",
+      "invitedToProjectNeedsAccount": "You have been invited by {{inviter}} to join project {{project}}.",
       "selectOrganisation": "Wähle die Organisation aus, zu der du dieses Projekt hinzufügen möchtest:"
+    },
+    "needsAccount": {
+      "continue": "Weiter zur Anmeldung",
+      "description": "Du musst dich mit {{email}} anmelden oder ein Konto erstellen, um diese Einladung anzunehmen.",
+      "emailMatch": "Stelle sicher, dass du dich mit der E-Mail-Adresse anmeldest, an die diese Einladung gesendet wurde: {{email}}",
+      "title": "Konto erforderlich"
     },
     "title": {
       "invitationCreated": "Einladung erstellt",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -94,6 +94,9 @@
     "getStartedFree": "Get started with open source time tracking",
     "joinLasius": "Join Lasius",
     "needHelp": "Need help? Click the help button",
+    "needsAccount": {
+      "message": "To accept the invitation, please sign in with {{email}} or create a new account using one of the login providers below."
+    },
     "noAuthMethodsAvailable": "No authentication methods available",
     "preparingSecureLogin": "Preparing secure login...",
     "providers": {
@@ -392,8 +395,16 @@
     "inviteProjectDescription": "Enter the email address of the person you want to invite. An invitation link will be generated that you can send to them.",
     "messages": {
       "invitedToOrganisation": "You have been invited by {{inviter}} to join organisation {{organisation}}.",
+      "invitedToOrganisationNeedsAccount": "You have been invited by {{inviter}} to join organisation {{organisation}}.",
       "invitedToProject": "You have been invited by {{inviter}} to join project {{project}}.",
+      "invitedToProjectNeedsAccount": "You have been invited by {{inviter}} to join project {{project}}.",
       "selectOrganisation": "Select the organisation you would like to add this project to:"
+    },
+    "needsAccount": {
+      "continue": "Continue to Sign In",
+      "description": "You'll need to sign in or create an account for {{email}} to accept this invitation.",
+      "emailMatch": "Make sure to sign in with the email address this invitation was sent to: {{email}}",
+      "title": "Account Required"
     },
     "title": {
       "invitationCreated": "Invitation created",

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -94,6 +94,9 @@
     "getStartedFree": "Comienza con el seguimiento del tiempo de código abierto",
     "joinLasius": "Únete a Lasius",
     "needHelp": "¿Necesitas ayuda? Haz clic en el botón de ayuda",
+    "needsAccount": {
+      "message": "Para aceptar la invitación, inicia sesión con {{email}} o crea una nueva cuenta usando uno de los proveedores de inicio de sesión que aparecen a continuación."
+    },
     "noAuthMethodsAvailable": "No hay métodos de autenticación disponibles",
     "preparingSecureLogin": "Preparando inicio de sesión seguro...",
     "providers": {
@@ -392,8 +395,16 @@
     "inviteProjectDescription": "Introduce la dirección de correo electrónico de la persona que deseas invitar. Se generará un enlace de invitación que puedes enviarle.",
     "messages": {
       "invitedToOrganisation": "Has sido invitado por {{inviter}} a unirte a la organización {{organisation}}.",
+      "invitedToOrganisationNeedsAccount": "You have been invited by {{inviter}} to join organisation {{organisation}}.",
       "invitedToProject": "Has sido invitado por {{inviter}} a unirte al proyecto {{project}}.",
+      "invitedToProjectNeedsAccount": "You have been invited by {{inviter}} to join project {{project}}.",
       "selectOrganisation": "Selecciona la organización a la que quieres añadir este proyecto:"
+    },
+    "needsAccount": {
+      "continue": "Continuar al inicio de sesión",
+      "description": "Necesitarás iniciar sesión o crear una cuenta para {{email}} para aceptar esta invitación.",
+      "emailMatch": "Asegúrate de iniciar sesión con la dirección de correo electrónico a la que se envió esta invitación: {{email}}",
+      "title": "Cuenta requerida"
     },
     "title": {
       "invitationCreated": "Invitación creada",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -94,6 +94,9 @@
     "getStartedFree": "Commence avec le suivi du temps open source",
     "joinLasius": "Rejoindre Lasius",
     "needHelp": "Besoin d'aide ? Clique sur le bouton d'aide",
+    "needsAccount": {
+      "message": "Pour accepter l'invitation, connecte-toi avec {{email}} ou crée un nouveau compte en utilisant l'un des fournisseurs de connexion ci-dessous."
+    },
     "noAuthMethodsAvailable": "Aucune méthode d'authentification disponible",
     "preparingSecureLogin": "Préparation de la connexion sécurisée...",
     "providers": {
@@ -392,8 +395,16 @@
     "inviteProjectDescription": "Saisissez l'adresse e-mail de la personne que vous souhaitez inviter. Un lien d'invitation sera généré que vous pourrez lui envoyer.",
     "messages": {
       "invitedToOrganisation": "Tu as été invité par {{inviter}} à rejoindre l'organisation {{organisation}}.",
+      "invitedToOrganisationNeedsAccount": "You have been invited by {{inviter}} to join organisation {{organisation}}.",
       "invitedToProject": "Tu as été invité par {{inviter}} à rejoindre le projet {{project}}.",
+      "invitedToProjectNeedsAccount": "You have been invited by {{inviter}} to join project {{project}}.",
       "selectOrganisation": "Sélectionne l'organisation à laquelle tu souhaites ajouter ce projet :"
+    },
+    "needsAccount": {
+      "continue": "Continuer vers la connexion",
+      "description": "Tu devras te connecter ou créer un compte pour {{email}} afin d'accepter cette invitation.",
+      "emailMatch": "Assure-toi de te connecter avec l'adresse e-mail à laquelle cette invitation a été envoyée : {{email}}",
+      "title": "Compte requis"
     },
     "title": {
       "invitationCreated": "Invitation créée",

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -94,6 +94,9 @@
     "getStartedFree": "Inizia con il monitoraggio tempo open source",
     "joinLasius": "Unisciti a Lasius",
     "needHelp": "Serve aiuto? Clicca sul pulsante di aiuto",
+    "needsAccount": {
+      "message": "Per accettare l'invito, accedi con {{email}} o crea un nuovo account utilizzando uno dei provider di accesso qui sotto."
+    },
     "noAuthMethodsAvailable": "Nessun metodo di autenticazione disponibile",
     "preparingSecureLogin": "Preparazione accesso sicuro in corso...",
     "providers": {
@@ -392,8 +395,16 @@
     "inviteProjectDescription": "Inserisci l'indirizzo email della persona che desideri invitare. Verrà generato un link di invito che potrai inviarle.",
     "messages": {
       "invitedToOrganisation": "Sei stato invitato da {{inviter}} a unirti all'organizzazione {{organisation}}.",
+      "invitedToOrganisationNeedsAccount": "You have been invited by {{inviter}} to join organisation {{organisation}}.",
       "invitedToProject": "Sei stato invitato da {{inviter}} a unirti al progetto {{project}}.",
+      "invitedToProjectNeedsAccount": "You have been invited by {{inviter}} to join project {{project}}.",
       "selectOrganisation": "Seleziona l'organizzazione a cui vuoi aggiungere questo progetto:"
+    },
+    "needsAccount": {
+      "continue": "Continua all'accesso",
+      "description": "Dovrai accedere o creare un account per {{email}} per accettare questo invito.",
+      "emailMatch": "Assicurati di accedere con l'indirizzo email a cui è stato inviato questo invito: {{email}}",
+      "title": "Account richiesto"
     },
     "title": {
       "invitationCreated": "Invito creato",

--- a/frontend/src/components/features/invitation/InvitationNeedsAccount.tsx
+++ b/frontend/src/components/features/invitation/InvitationNeedsAccount.tsx
@@ -1,0 +1,115 @@
+/**
+ * Lasius - Open source time tracker for teams
+ * Copyright (c) Tegonal Genossenschaft (https://tegonal.com)
+ *
+ * This file is part of Lasius.
+ *
+ * Lasius is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Lasius is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with Lasius.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+import { LoginInfoPanel } from 'components/features/login/authInfoPanels'
+import { AuthLayout } from 'components/features/login/authLayout'
+import { Button } from 'components/primitives/buttons/Button'
+import { Card, CardBody } from 'components/ui/cards/Card'
+import { Alert } from 'components/ui/feedback/Alert'
+import { LucideIcon } from 'components/ui/icons/LucideIcon'
+import {
+  ModelsInvitationStatusResponse,
+  ModelsJoinOrganisationInvitation,
+  ModelsJoinProjectInvitation,
+} from 'lib/api/lasius'
+import { LogIn } from 'lucide-react'
+import { useTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
+import React from 'react'
+
+type Props = {
+  invitation: ModelsInvitationStatusResponse
+  locale?: string
+}
+
+export const InvitationNeedsAccount: React.FC<Props> = ({ invitation, locale }) => {
+  const { t } = useTranslation('common')
+  const router = useRouter()
+
+  const handleContinue = () => {
+    const url =
+      '/login?' +
+      new URLSearchParams({
+        invitation_id: invitation.invitation.id,
+        email: invitation.invitation.invitedEmail,
+        locale: locale || '',
+        needs_account: 'true',
+      })
+    router.push(url)
+  }
+
+  const invitationMessage =
+    invitation.invitation.type === 'JoinOrganisationInvitation'
+      ? t('invitations.messages.invitedToOrganisationNeedsAccount', {
+          defaultValue:
+            'You have been invited by {{inviter}} to join organisation {{organisation}}.',
+          inviter: invitation.invitation.createdBy.key,
+          organisation: (invitation.invitation as ModelsJoinOrganisationInvitation)
+            .organisationReference.key,
+        })
+      : t('invitations.messages.invitedToProjectNeedsAccount', {
+          defaultValue: 'You have been invited by {{inviter}} to join project {{project}}.',
+          inviter: invitation.invitation.createdBy.key,
+          project: (invitation.invitation as ModelsJoinProjectInvitation).projectReference.key,
+        })
+
+  return (
+    <AuthLayout infoPanel={<LoginInfoPanel />}>
+      {/* Info Alert */}
+      <Alert variant="info">{invitationMessage}</Alert>
+
+      {/* Main card */}
+      <Card className="bg-base-100/80 border-0 shadow-2xl backdrop-blur-sm">
+        <CardBody className="p-8 lg:p-10">
+          <div className="mb-8 space-y-4 text-center">
+            <h2 className="text-3xl font-bold">
+              {t('invitations.needsAccount.title', {
+                defaultValue: 'Account Required',
+              })}
+            </h2>
+            <p className="text-base-content/60">
+              {t('invitations.needsAccount.description', {
+                defaultValue:
+                  "You'll need to sign in or create an account for {{email}} to accept this invitation.",
+                email: invitation.invitation.invitedEmail,
+              })}
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <Alert variant="warning">
+              {t('invitations.needsAccount.emailMatch', {
+                defaultValue:
+                  'Make sure to sign in with the email address this invitation was sent to: {{email}}',
+                email: invitation.invitation.invitedEmail,
+              })}
+            </Alert>
+
+            <Button onClick={handleContinue} fullWidth size="lg" className="gap-2">
+              <LucideIcon icon={LogIn} size={18} />
+              {t('invitations.needsAccount.continue', {
+                defaultValue: 'Continue to Sign In',
+              })}
+            </Button>
+          </div>
+        </CardBody>
+      </Card>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/components/features/projects/projectAddUpdateForm.tsx
+++ b/frontend/src/components/features/projects/projectAddUpdateForm.tsx
@@ -33,7 +33,11 @@ import { ModalDescription } from 'components/ui/overlays/modal/ModalDescription'
 import { ModalHeader } from 'components/ui/overlays/modal/ModalHeader'
 import { useOrganisation } from 'lib/api/hooks/useOrganisation'
 import { ModelsProject, ModelsUserProject } from 'lib/api/lasius'
-import { createProject, updateProject } from 'lib/api/lasius/projects/projects'
+import {
+  createProject,
+  getGetProjectListKey,
+  updateProject,
+} from 'lib/api/lasius/projects/projects'
 import { getGetUserProfileKey } from 'lib/api/lasius/user/user'
 import { useTranslation } from 'next-i18next'
 import React, { useMemo, useState } from 'react'
@@ -112,6 +116,7 @@ export const ProjectAddUpdateForm: React.FC<Props> = ({ mode, item, onCancel, on
         })
       }
 
+      await mutate(getGetProjectListKey(selectedOrganisationId))
       await mutate(getGetUserProfileKey())
       onSave()
     } catch (error) {

--- a/frontend/src/pages/join/[invitationId].tsx
+++ b/frontend/src/pages/join/[invitationId].tsx
@@ -18,6 +18,7 @@
  */
 
 import { InvitationInvalid } from 'components/features/invitation/invitationInvalid'
+import { InvitationNeedsAccount } from 'components/features/invitation/InvitationNeedsAccount'
 import { InvitationOtherSession } from 'components/features/invitation/InvitationOtherSession'
 import { InvitationUserConfirm } from 'components/features/invitation/invitationUserConfirm'
 import { getInvitationStatus } from 'lib/api/lasius/invitations-public/invitations-public'
@@ -47,22 +48,15 @@ const Join: NextPage<{ session: Session; locale?: string }> = ({ session, locale
 
   const invitation = invitationStatus.result
 
-  if (invitation?.invitation?.id && invitation?.invitation?.invitedEmail && session === null) {
-    logger.info('[Join][NotAuthenticated]', session)
-    // login user and handle invitation logic again
-    const url =
-      '/login?' +
-      new URLSearchParams({
-        invitation_id: invitation.invitation?.id,
-        email: invitation.invitation?.invitedEmail,
-        locale: locale || '',
-      })
-    router.replace(url)
+  if (invitation?.invitation?.id && invitation?.invitation?.invitedEmail && !session) {
+    logger.info('[Join][NotAuthenticated]', { session, status: invitation.status })
+    // Show appropriate component based on whether user exists
+    return <InvitationNeedsAccount invitation={invitation} locale={locale} />
   }
 
-  if (invitation && session !== null) {
+  if (invitation && session) {
     // check if invitation matches current users session
-    if (session.user && session.user.email !== invitation.invitation.invitedEmail) {
+    if (session?.user?.email && session.user.email !== invitation.invitation.invitedEmail) {
       return (
         <>
           <NextSeo

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -67,7 +67,13 @@ const Login: NextPage<{
   const { t } = useTranslation('common')
   const router = useRouter()
   const { setSelectedDate } = useCalendarActions()
-  const { invitation_id = null, email = null, error = null, callbackUrl = null } = router.query
+  const {
+    invitation_id = null,
+    email = null,
+    error = null,
+    callbackUrl = null,
+    needs_account = null,
+  } = router.query
 
   // Build dynamic translation key for error messages
   const getErrorMessage = (errorCode: string | string[] | null): string => {
@@ -249,9 +255,16 @@ const Login: NextPage<{
       />
       <AuthLayout infoPanel={<LoginInfoPanel />}>
         {/* Error Alert */}
-        {error && (
-          <Alert variant="warning" className="animate-[fadeIn_0.4s_ease-out]">
-            {getErrorMessage(error)}
+        {error && <Alert variant="warning">{getErrorMessage(error)}</Alert>}
+
+        {/* New account required for invitation */}
+        {needs_account && email && (
+          <Alert variant="info">
+            {t('auth.needsAccount.message', {
+              defaultValue:
+                'To accept the invitation, please sign in with {{email}} or create a new account using one of the login providers below.',
+              email: email,
+            })}
           </Alert>
         )}
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4258,10 +4258,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"daisyui@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "daisyui@npm:5.3.0"
-  checksum: 10/9568326110231ce68427b50d13b0831721a1387a710b0ab116a932f9b2bc77004f2dde039b781893efcd8c538b94be6d084cfa0f19634eefed9de87b8feb8f3e
+"daisyui@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "daisyui@npm:5.3.2"
+  checksum: 10/f8d37fc598a7a1c2151f20da2273246414c93b248cb7789e6d7fa9710d97b54906fcc6345cb7ae497b4bc9b0d1269cbd619cfb88ed958fa281a0e09cfe4797af
   languageName: node
   linkType: hard
 
@@ -7217,7 +7217,7 @@ __metadata:
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
     concurrently: "npm:^9.2.1"
-    daisyui: "npm:^5.3.0"
+    daisyui: "npm:^5.3.2"
     date-fns: "npm:^4.1.0"
     date-fns-tz: "npm:^3.2.0"
     dotenv-cli: "npm:^10.0.0"
@@ -7251,7 +7251,7 @@ __metadata:
     orval: "npm:7.13.2"
     parse-json: "npm:^8.3.0"
     prettier: "npm:^3.6.2"
-    prettier-plugin-tailwindcss: "npm:^0.6.14"
+    prettier-plugin-tailwindcss: "npm:^0.7.0"
     react: "npm:19.2.0"
     react-async-hook: "npm:^4.0.0"
     react-dom: "npm:19.2.0"
@@ -9137,9 +9137,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-tailwindcss@npm:^0.6.14":
-  version: 0.6.14
-  resolution: "prettier-plugin-tailwindcss@npm:0.6.14"
+"prettier-plugin-tailwindcss@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "prettier-plugin-tailwindcss@npm:0.7.0"
   peerDependencies:
     "@ianvs/prettier-plugin-sort-imports": "*"
     "@prettier/plugin-hermes": "*"
@@ -9151,14 +9151,12 @@ __metadata:
     prettier: ^3.0
     prettier-plugin-astro: "*"
     prettier-plugin-css-order: "*"
-    prettier-plugin-import-sort: "*"
     prettier-plugin-jsdoc: "*"
     prettier-plugin-marko: "*"
     prettier-plugin-multiline-arrays: "*"
     prettier-plugin-organize-attributes: "*"
     prettier-plugin-organize-imports: "*"
     prettier-plugin-sort-imports: "*"
-    prettier-plugin-style-order: "*"
     prettier-plugin-svelte: "*"
   peerDependenciesMeta:
     "@ianvs/prettier-plugin-sort-imports":
@@ -9179,8 +9177,6 @@ __metadata:
       optional: true
     prettier-plugin-css-order:
       optional: true
-    prettier-plugin-import-sort:
-      optional: true
     prettier-plugin-jsdoc:
       optional: true
     prettier-plugin-marko:
@@ -9193,11 +9189,9 @@ __metadata:
       optional: true
     prettier-plugin-sort-imports:
       optional: true
-    prettier-plugin-style-order:
-      optional: true
     prettier-plugin-svelte:
       optional: true
-  checksum: 10/84235df312878176f7019272d921923943895f08120393e40f518c4c5f572e6adf11fdd9fbe9c92b9d7210ed1f9c6605e89de1b627b6ac2cf8480e199ee80e26
+  checksum: 10/8e48f97fdd9af13a8e6ad70d08088d504efe9b4e32227ae9d184387890aa9fd871ff340c26a3f7b3be73408f3f4369fae59073444e9df00f4ac8eb5017b6cd69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces a new user flow for handling invitation acceptance when authentication is required, improves localization for this flow across multiple languages, and updates dependencies to their latest versions. The main changes include adding a dedicated component for the "needs account" state, updating the invitation join and login pages to use this new flow, and extending translation files to support the new messaging. Additionally, there is a minor fix to ensure project lists are updated after project changes.

**Invitation flow improvements:**

* Added new `InvitationNeedsAccount` component to display a dedicated UI when a user needs to sign in or create an account to accept an invitation. This component provides contextual messaging and a call-to-action for authentication. (`frontend/src/components/features/invitation/InvitationNeedsAccount.tsx`)
* Updated the invitation join page to render the new `InvitationNeedsAccount` component instead of redirecting unauthenticated users, providing a clearer experience for invited users without an active session. (`frontend/src/pages/join/[invitationId].tsx`) ([frontend/src/pages/join/[invitationId].tsxR21](diffhunk://#diff-a850c90ffedd29ae786772f11498c478ac9450ea98ec40f9ec65e049bf3b2f3cR21), [frontend/src/pages/join/[invitationId].tsxL50-R59](diffhunk://#diff-a850c90ffedd29ae786772f11498c478ac9450ea98ec40f9ec65e049bf3b2f3cL50-R59))
* Improved the login page to display an informational alert when accessed via an invitation that requires account creation, using the new translation keys. (`frontend/src/pages/login.tsx`) [[1]](diffhunk://#diff-208b36ba8dda03d1de3027b0bbc2940355bb347d43cdcafdac82ba1f797f4e5bL70-R76) [[2]](diffhunk://#diff-208b36ba8dda03d1de3027b0bbc2940355bb347d43cdcafdac82ba1f797f4e5bL252-R267)

**Localization enhancements:**

* Extended translation files (`common.json`) in English, German, Spanish, French, and Italian to include new keys and messages for the "needs account" invitation flow, ensuring users receive clear instructions in their language. (`frontend/public/locales/en/common.json`, `frontend/public/locales/de/common.json`, `frontend/public/locales/es/common.json`, `frontend/public/locales/fr/common.json`, `frontend/public/locales/it/common.json`) [[1]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aR97-R99) [[2]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aR398-R408) [[3]](diffhunk://#diff-2e67589bc551d2f12ba1499b32925674c0611ff673460af46437902cab5f058eR97-R99) [[4]](diffhunk://#diff-2e67589bc551d2f12ba1499b32925674c0611ff673460af46437902cab5f058eR398-R408) [[5]](diffhunk://#diff-13c52b69dfe950d320432dae53ccb8a566a5d4d69ac5a7ba54f4a909a3bb4e6fR97-R99) [[6]](diffhunk://#diff-13c52b69dfe950d320432dae53ccb8a566a5d4d69ac5a7ba54f4a909a3bb4e6fR398-R408) [[7]](diffhunk://#diff-285d4745ded42255660eafafa54fc7490496e86f0ed40a9d9ea2f6687b8b32d6R97-R99) [[8]](diffhunk://#diff-285d4745ded42255660eafafa54fc7490496e86f0ed40a9d9ea2f6687b8b32d6R398-R408) [[9]](diffhunk://#diff-7f4d6bada4d4e07a00f12836e045c0d3337f22b8b4cee8a62ec4d4d807f084a5R97-R99) [[10]](diffhunk://#diff-7f4d6bada4d4e07a00f12836e045c0d3337f22b8b4cee8a62ec4d4d807f084a5R398-R408)

**Dependency updates:**

* Updated `daisyui` and `prettier-plugin-tailwindcss` to their latest versions in `package.json` for improved stability and features. (`frontend/package.json`) [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L105-R105) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L123-R123)

**Minor fixes:**

* Ensured that the project list is refreshed after creating or updating a project by calling the relevant mutation hook. (`frontend/src/components/features/projects/projectAddUpdateForm.tsx`) [[1]](diffhunk://#diff-04f27bc615c02a0719f5a84b7ab807e4c4433a7b497ced645359865eeca81306L36-R40) [[2]](diffhunk://#diff-04f27bc615c02a0719f5a84b7ab807e4c4433a7b497ced645359865eeca81306R119)
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/lasius/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.