### PR TITLE
Fix tag input focus after project selection

### DIFF
--- a/frontend/src/components/ui/forms/input/InputTagsAutocomplete.tsx
+++ b/frontend/src/components/ui/forms/input/InputTagsAutocomplete.tsx
@@ -150,12 +150,15 @@ export const InputTagsAutocomplete: React.FC<Props> = ({ suggestions = [], name,
         <Controller
           name={name}
           control={parentFormContext.control}
-          render={() => (
+          render={({ field }) => (
             <Combobox value={selectedTags} onChange={addTag}>
               {({ open }) => (
                 <>
                   <ComboboxInput
-                    ref={inputRef}
+                    ref={(el: HTMLInputElement | null) => {
+                      inputRef.current = el
+                      field.ref(el)
+                    }}
                     id={id || name}
                     className="input input-bordered w-full pr-10 text-sm"
                     onChange={inputValueChanged}


### PR DESCRIPTION
## Summary

Closes #386

- Forward react-hook-form's `field.ref` to the `ComboboxInput` in `InputTagsAutocomplete` so that `hookForm.setFocus('tags')` can reach the DOM element
- The `setFocus('tags')` calls already existed in all 4 booking forms but silently failed because the Controller's render callback never attached `field.ref`

## Test plan

- [ ] Start a new booking, select a project — tag input should auto-focus
- [ ] Edit a running booking, change project — tag input should auto-focus
- [ ] Add a tag — input should refocus for continuous entry (existing behavior)
- [ ] `yarn check` passes