### PR TITLE
Improve tag group help text to explain booking behavior

### DIFF
--- a/frontend/public/help/de/modal-add-edit-booking.mdx
+++ b/frontend/public/help/de/modal-add-edit-booking.mdx
@@ -17,7 +17,8 @@ Die Auswahl einer Vorlage füllt automatisch Projekt und Tags aus.
 1. Wähle ein **Projekt** aus der Dropdown-Liste (erforderlich)
 2. Füge **Tags** hinzu, um deine Arbeit zu kategorisieren
    - Tippe zum Suchen oder wähle aus verfügbaren Tags
-   - Verwende Tag-Gruppen für konsistente Kategorisierung
+   - Wähle eine **Tag-Gruppe** aus, um alle enthaltenen Tags auf einmal anzuwenden (z.B. könnte eine Gruppe «Kundenarbeit» die Tags «Verrechenbar», «Frontend» und «Review» mit einem Klick hinzufügen)
+   - Wähle **einfache Tags** einzeln für eigenständige Kategorien
 
 ### Zeiteingabe
 

--- a/frontend/public/help/de/modal-edit-tags.mdx
+++ b/frontend/public/help/de/modal-edit-tags.mdx
@@ -2,10 +2,19 @@
 
 Verwalte Tags und Tag-Gruppen für dein Projekt, um Buchungen für eine bessere Berichterstattung zu kategorisieren und zu filtern.
 
+## Wie Tags funktionieren
+
+Beim Erstellen einer Buchung wählen Teammitglieder Tags aus, um ihre Arbeit zu kategorisieren. Es gibt zwei Arten:
+
+- **Tag-Gruppen**: Ein benanntes Set von Tags, die zusammengehören. Wenn ein Teammitglied bei der Buchung eine Tag-Gruppe auswählt, werden alle enthaltenen Tags auf einmal angewendet. Zum Beispiel könnte eine Tag-Gruppe «Kundenarbeit» Tags wie «Verrechenbar», «Frontend» und «Review» enthalten — die Auswahl von «Kundenarbeit» fügt alle drei automatisch hinzu.
+- **Einfache Tags**: Eigenständige Tags, die einzeln ausgewählt werden.
+
+Sowohl Tag-Gruppen als auch einfache Tags erscheinen im Tag-Picker beim Erstellen oder Bearbeiten einer Buchung. Sie stehen auch zum Filtern in den Ansichten Statistiken und Listen zur Verfügung.
+
 ## Benutzeroberfläche im Überblick
 
 Der Tag-Manager hat zwei Tabs:
-- **Tag-Gruppen**: Organisierte Sammlungen verwandter Tags
+- **Tag-Gruppen**: Benannte Sets verwandter Tags (werden bei Auswahl gemeinsam angewendet)
 - **Einfache Tags**: Einzelne Tags, die nicht Teil einer Gruppe sind
 
 ## Tab "Tag-Gruppen"
@@ -65,12 +74,12 @@ Füge einzelne Tags hinzu, die unabhängig verwendet werden können:
 
 ## Tipps
 
-<Tip>Tag-Gruppen stellen konsistentes Tagging über Teammitglieder hinweg sicher</Tip>
+<Tip>Tag-Gruppen werden als Ganzes angewendet — die Auswahl einer Tag-Gruppe bei der Buchung fügt alle enthaltenen Tags auf einmal hinzu und stellt so eine konsistente Kategorisierung über Teammitglieder hinweg sicher</Tip>
 
 <Tip>Tag-Gruppen werden automatisch alphabetisch sortiert</Tip>
 
 <Tip>Verwende Kopieren/Einfügen, um Tag-Strukturen schnell über Gruppen hinweg zu duplizieren</Tip>
 
-<Tip>Verwende einfache Tags für einmalige Kategorien, die keine Gruppierung benötigen</Tip>
+<Tip>Verwende einfache Tags für eigenständige Kategorien, die nicht mit anderen Tags gebündelt werden müssen</Tip>
 
-<Tip>Tags ermöglichen detailliertes Filtern in den Ansichten Statistiken und Listen</Tip>
+<Tip>Sowohl Tag-Gruppen als auch einfache Tags können zum Filtern in den Ansichten Statistiken und Listen verwendet werden</Tip>

--- a/frontend/public/help/en/modal-add-edit-booking.mdx
+++ b/frontend/public/help/en/modal-add-edit-booking.mdx
@@ -17,7 +17,8 @@ Selecting a preset automatically fills in the project and tags.
 1. Select a **Project** from the dropdown (required)
 2. Add **Tags** to categorize your work
    - Type to search or select from available tags
-   - Use tag groups for consistent categorization
+   - Select a **tag group** to apply all its tags at once (e.g., a "Client Work" group might add "Billable", "Frontend", and "Review" in one click)
+   - Select **simple tags** individually for standalone categories
 
 ### Time Entry
 

--- a/frontend/public/help/en/modal-edit-tags.mdx
+++ b/frontend/public/help/en/modal-edit-tags.mdx
@@ -2,10 +2,19 @@
 
 Manage tags and tag groups for your project to categorize and filter bookings for better reporting.
 
+## How Tags Work
+
+When creating a booking, team members select tags to categorize their work. There are two kinds:
+
+- **Tag Groups**: A named set of tags that belong together. When a team member selects a tag group during booking, all its tags are applied at once. For example, a "Client Work" tag group might include tags like "Billable", "Frontend", and "Review" — selecting "Client Work" adds all three automatically.
+- **Simple Tags**: Standalone tags that are selected individually.
+
+Both tag groups and simple tags appear in the tag picker when creating or editing a booking. They are also available for filtering in Statistics and Lists views.
+
 ## Interface Overview
 
 The tag manager has two tabs:
-- **Tag Groups**: Organized collections of related tags
+- **Tag Groups**: Named sets of related tags (applied together when selected)
 - **Simple Tags**: Individual tags not part of any group
 
 ## Tag Groups Tab
@@ -65,12 +74,12 @@ Add individual tags that can be used independently:
 
 ## Tips
 
-<Tip>Tag groups ensure consistent tagging across team members</Tip>
+<Tip>Tag groups are applied as a whole — selecting a tag group during booking adds all its tags at once, ensuring consistent categorization across team members</Tip>
 
 <Tip>Tag groups are automatically sorted alphabetically</Tip>
 
 <Tip>Use copy/paste to quickly duplicate tag structures across groups</Tip>
 
-<Tip>Use simple tags for one-off categories that don't need grouping</Tip>
+<Tip>Use simple tags for standalone categories that don't need to be bundled with other tags</Tip>
 
-<Tip>Tags enable detailed filtering in Statistics and Lists views</Tip>
+<Tip>Both tag groups and simple tags can be used for filtering in Statistics and Lists views</Tip>

--- a/frontend/public/help/es/modal-add-edit-booking.mdx
+++ b/frontend/public/help/es/modal-add-edit-booking.mdx
@@ -17,7 +17,8 @@ Al seleccionar un preajuste se rellenan automáticamente el proyecto y las etiqu
 1. Selecciona un **Proyecto** del menú desplegable (obligatorio)
 2. Añade **Etiquetas** para categorizar tu trabajo
    - Escribe para buscar o selecciona entre las etiquetas disponibles
-   - Usa grupos de etiquetas para una categorización coherente
+   - Selecciona un **grupo de etiquetas** para aplicar todas sus etiquetas a la vez (por ej., un grupo «Trabajo cliente» podría añadir «Facturable», «Frontend» y «Revisión» con un clic)
+   - Selecciona **etiquetas simples** individualmente para categorías independientes
 
 ### Entrada de Tiempo
 

--- a/frontend/public/help/es/modal-edit-tags.mdx
+++ b/frontend/public/help/es/modal-edit-tags.mdx
@@ -2,10 +2,19 @@
 
 Gestiona las etiquetas y grupos de etiquetas de tu proyecto para categorizar y filtrar registros para mejores informes.
 
+## Cómo funcionan las etiquetas
+
+Al crear un registro, los miembros del equipo seleccionan etiquetas para categorizar su trabajo. Hay dos tipos:
+
+- **Grupos de etiquetas**: Un conjunto con nombre de etiquetas que pertenecen juntas. Cuando un miembro del equipo selecciona un grupo de etiquetas durante el registro, todas sus etiquetas se aplican a la vez. Por ejemplo, un grupo de etiquetas «Trabajo cliente» podría incluir etiquetas como «Facturable», «Frontend» y «Revisión» — seleccionar «Trabajo cliente» añade las tres automáticamente.
+- **Etiquetas simples**: Etiquetas independientes que se seleccionan individualmente.
+
+Tanto los grupos de etiquetas como las etiquetas simples aparecen en el selector de etiquetas al crear o editar un registro. También están disponibles para filtrar en las vistas de Estadísticas y Listas.
+
 ## Descripción general de la interfaz
 
 El gestor de etiquetas tiene dos pestañas:
-- **Grupos de etiquetas**: Colecciones organizadas de etiquetas relacionadas
+- **Grupos de etiquetas**: Conjuntos con nombre de etiquetas relacionadas (se aplican juntas al seleccionarlas)
 - **Etiquetas simples**: Etiquetas individuales que no forman parte de ningún grupo
 
 ## Pestaña Grupos de etiquetas
@@ -65,12 +74,12 @@ Añade etiquetas individuales que se pueden usar de forma independiente:
 
 ## Consejos
 
-<Tip>Los grupos de etiquetas aseguran un etiquetado coherente entre los miembros del equipo</Tip>
+<Tip>Los grupos de etiquetas se aplican en su conjunto — seleccionar un grupo de etiquetas durante el registro añade todas sus etiquetas a la vez, asegurando una categorización coherente entre los miembros del equipo</Tip>
 
 <Tip>Los grupos de etiquetas se ordenan automáticamente alfabéticamente</Tip>
 
 <Tip>Usa copiar/pegar para duplicar rápidamente estructuras de etiquetas entre grupos</Tip>
 
-<Tip>Usa etiquetas simples para categorías puntuales que no necesitan agruparse</Tip>
+<Tip>Usa etiquetas simples para categorías independientes que no necesitan agruparse con otras etiquetas</Tip>
 
-<Tip>Las etiquetas permiten un filtrado detallado en las vistas de Estadísticas y Listas</Tip>
+<Tip>Tanto los grupos de etiquetas como las etiquetas simples se pueden usar para filtrar en las vistas de Estadísticas y Listas</Tip>

--- a/frontend/public/help/fr/modal-add-edit-booking.mdx
+++ b/frontend/public/help/fr/modal-add-edit-booking.mdx
@@ -17,7 +17,8 @@ La sélection d'un préréglage remplit automatiquement le projet et les étique
 1. Sélectionne un **Projet** dans le menu déroulant (obligatoire)
 2. Ajoute des **Étiquettes** pour catégoriser ton travail
    - Tape pour rechercher ou sélectionne parmi les étiquettes disponibles
-   - Utilise les groupes d'étiquettes pour une catégorisation cohérente
+   - Sélectionne un **groupe d'étiquettes** pour appliquer toutes ses étiquettes en une fois (par ex., un groupe « Travail client » pourrait ajouter « Facturable », « Frontend » et « Revue » en un clic)
+   - Sélectionne des **étiquettes simples** individuellement pour des catégories autonomes
 
 ### Saisie du temps
 

--- a/frontend/public/help/fr/modal-edit-tags.mdx
+++ b/frontend/public/help/fr/modal-edit-tags.mdx
@@ -2,10 +2,19 @@
 
 Gère les étiquettes et les groupes d'étiquettes pour ton projet afin de catégoriser et filtrer les réservations pour de meilleurs rapports.
 
+## Comment fonctionnent les étiquettes
+
+Lors de la création d'une réservation, les membres de l'équipe sélectionnent des étiquettes pour catégoriser leur travail. Il existe deux types :
+
+- **Groupes d'étiquettes** : Un ensemble nommé d'étiquettes qui vont ensemble. Lorsqu'un membre de l'équipe sélectionne un groupe d'étiquettes lors d'une réservation, toutes ses étiquettes sont appliquées en une fois. Par exemple, un groupe d'étiquettes « Travail client » pourrait inclure des étiquettes comme « Facturable », « Frontend » et « Revue » — sélectionner « Travail client » ajoute les trois automatiquement.
+- **Étiquettes simples** : Étiquettes autonomes qui sont sélectionnées individuellement.
+
+Les groupes d'étiquettes et les étiquettes simples apparaissent dans le sélecteur d'étiquettes lors de la création ou la modification d'une réservation. Ils sont également disponibles pour le filtrage dans les vues Statistiques et Listes.
+
 ## Aperçu de l'interface
 
 Le gestionnaire d'étiquettes comporte deux onglets :
-- **Groupes d'étiquettes** : Collections organisées d'étiquettes connexes
+- **Groupes d'étiquettes** : Ensembles nommés d'étiquettes connexes (appliqués ensemble lors de la sélection)
 - **Étiquettes simples** : Étiquettes individuelles ne faisant partie d'aucun groupe
 
 ## Onglet Groupes d'étiquettes
@@ -65,12 +74,12 @@ Ajoute des étiquettes individuelles qui peuvent être utilisées indépendammen
 
 ## Conseils
 
-<Tip>Les groupes d'étiquettes garantissent un étiquetage cohérent entre les membres de l'équipe</Tip>
+<Tip>Les groupes d'étiquettes sont appliqués dans leur ensemble — sélectionner un groupe d'étiquettes lors d'une réservation ajoute toutes ses étiquettes en une fois, garantissant une catégorisation cohérente entre les membres de l'équipe</Tip>
 
 <Tip>Les groupes d'étiquettes sont automatiquement triés par ordre alphabétique</Tip>
 
 <Tip>Utilise copier/coller pour dupliquer rapidement les structures d'étiquettes entre les groupes</Tip>
 
-<Tip>Utilise des étiquettes simples pour des catégories ponctuelles qui ne nécessitent pas de regroupement</Tip>
+<Tip>Utilise des étiquettes simples pour des catégories autonomes qui n'ont pas besoin d'être regroupées avec d'autres étiquettes</Tip>
 
-<Tip>Les étiquettes permettent un filtrage détaillé dans les vues Statistiques et Listes</Tip>
+<Tip>Les groupes d'étiquettes et les étiquettes simples peuvent être utilisés pour le filtrage dans les vues Statistiques et Listes</Tip>

--- a/frontend/public/help/it/modal-add-edit-booking.mdx
+++ b/frontend/public/help/it/modal-add-edit-booking.mdx
@@ -17,7 +17,8 @@ Selezionare una preimpostazione compila automaticamente il progetto e le etichet
 1. Seleziona un **Progetto** dal menu a discesa (obbligatorio)
 2. Aggiungi **Etichette** per categorizzare il tuo lavoro
    - Digiti per cercare o selezioni dalle etichette disponibili
-   - Usa i gruppi di etichette per una categorizzazione coerente
+   - Seleziona un **gruppo di etichette** per applicare tutte le sue etichette in una volta (ad es., un gruppo «Lavoro cliente» potrebbe aggiungere «Fatturabile», «Frontend» e «Revisione» con un clic)
+   - Seleziona le **etichette semplici** singolarmente per categorie autonome
 
 ### Inserimento Tempo
 

--- a/frontend/public/help/it/modal-edit-tags.mdx
+++ b/frontend/public/help/it/modal-edit-tags.mdx
@@ -2,10 +2,19 @@
 
 Gestisci le etichette e i gruppi di etichette per il tuo progetto per categorizzare e filtrare le registrazioni per una migliore reportistica.
 
+## Come funzionano le etichette
+
+Quando si crea una registrazione, i membri del team selezionano le etichette per categorizzare il loro lavoro. Esistono due tipi:
+
+- **Gruppi di etichette**: Un insieme denominato di etichette che appartengono insieme. Quando un membro del team seleziona un gruppo di etichette durante la registrazione, tutte le sue etichette vengono applicate in una volta. Ad esempio, un gruppo di etichette «Lavoro cliente» potrebbe includere etichette come «Fatturabile», «Frontend» e «Revisione» — selezionando «Lavoro cliente» si aggiungono tutte e tre automaticamente.
+- **Etichette semplici**: Etichette autonome che vengono selezionate singolarmente.
+
+Sia i gruppi di etichette che le etichette semplici appaiono nel selettore di etichette quando si crea o modifica una registrazione. Sono anche disponibili per il filtraggio nelle viste Statistiche ed Elenchi.
+
 ## Panoramica dell'interfaccia
 
 Il gestore delle etichette ha due schede:
-- **Gruppi di etichette**: Collezioni organizzate di etichette correlate
+- **Gruppi di etichette**: Insiemi denominati di etichette correlate (applicati insieme quando selezionati)
 - **Etichette semplici**: Etichette individuali che non fanno parte di alcun gruppo
 
 ## Scheda Gruppi di etichette
@@ -65,12 +74,12 @@ Aggiungi etichette individuali che possono essere utilizzate indipendentemente:
 
 ## Suggerimenti
 
-<Tip>I gruppi di etichette garantiscono un'etichettatura coerente tra i membri del team</Tip>
+<Tip>I gruppi di etichette vengono applicati nel loro insieme — selezionare un gruppo di etichette durante la registrazione aggiunge tutte le sue etichette in una volta, garantendo una categorizzazione coerente tra i membri del team</Tip>
 
 <Tip>I gruppi di etichette vengono ordinati automaticamente in ordine alfabetico</Tip>
 
 <Tip>Usa copia/incolla per duplicare rapidamente le strutture delle etichette tra i gruppi</Tip>
 
-<Tip>Usa le etichette semplici per categorie occasionali che non necessitano di raggruppamento</Tip>
+<Tip>Usa le etichette semplici per categorie autonome che non necessitano di essere raggruppate con altre etichette</Tip>
 
-<Tip>Le etichette consentono un filtraggio dettagliato nelle viste Statistiche ed Elenchi</Tip>
+<Tip>Sia i gruppi di etichette che le etichette semplici possono essere utilizzati per il filtraggio nelle viste Statistiche ed Elenchi</Tip>


### PR DESCRIPTION
## Summary
- Adds a "How Tags Work" section to the tag management help, explaining that selecting a tag group during booking applies all its tags at once
- Updates the booking help to clarify the difference between tag groups (applied as a set) and simple tags (selected individually)
- Translated across all 5 locales: EN, DE, FR, IT, ES

Addresses #388